### PR TITLE
Re-add horizon-always-configure-cache-backend.patch

### DIFF
--- a/patches/2024.1/horizon-always-configure-cache-backend.patch
+++ b/patches/2024.1/horizon-always-configure-cache-backend.patch
@@ -1,0 +1,19 @@
+--- a/ansible/roles/horizon/templates/_9998-kolla-settings.py.j2
++++ b/ansible/roles/horizon/templates/_9998-kolla-settings.py.j2
+@@ -18,7 +18,16 @@ DATABASES = {
+ }
+ {% elif groups['memcached'] | length > 0 and not horizon_backend_database | bool %}
+ SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
++{% endif %}
++
++{% if groups['memcached'] | length > 0 %}
+ CACHES['default']['LOCATION'] = [{% for host in groups['memcached'] %}'{{ 'api' | kolla_address(host) | put_address_in_context('url') }}:{{ memcached_port }}'{% if not loop.last %},{% endif %}{% endfor %}]
++CACHES['default']['OPTIONS'] =  {
++    "no_delay": True,
++    "ignore_exc": True,
++    "max_pool_size": 4,
++    "use_pooling": True,
++}
+ {% endif %}
+
+ {% if kolla_enable_tls_external | bool or kolla_enable_tls_internal | bool %}

--- a/patches/2024.2/horizon-always-configure-cache-backend.patch
+++ b/patches/2024.2/horizon-always-configure-cache-backend.patch
@@ -1,0 +1,19 @@
+--- a/ansible/roles/horizon/templates/_9998-kolla-settings.py.j2
++++ b/ansible/roles/horizon/templates/_9998-kolla-settings.py.j2
+@@ -18,7 +18,16 @@ DATABASES = {
+ }
+ {% elif groups['memcached'] | length > 0 and not horizon_backend_database | bool %}
+ SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
++{% endif %}
++
++{% if groups['memcached'] | length > 0 %}
+ CACHES['default']['LOCATION'] = [{% for host in groups['memcached'] %}'{{ 'api' | kolla_address(host) | put_address_in_context('url') }}:{{ memcached_port }}'{% if not loop.last %},{% endif %}{% endfor %}]
++CACHES['default']['OPTIONS'] =  {
++    "no_delay": True,
++    "ignore_exc": True,
++    "max_pool_size": 4,
++    "use_pooling": True,
++}
+ {% endif %}
+
+ {% if kolla_enable_tls_external | bool or kolla_enable_tls_internal | bool %}


### PR DESCRIPTION
Bring back horizon-always-configure-cache-backend.patch with improved default options.

Revert 0bc615232efc6325a176e428305de65e2a898094