### PR TITLE
Add octavia-openvswitch patch for 2024.2 and 2025.1

### DIFF
--- a/patches/2024.2/octavia-openvswitch.patch
+++ b/patches/2024.2/octavia-openvswitch.patch
@@ -1,0 +1,18 @@
+--- a/ansible/roles/openvswitch/defaults/main.yml
++++ b/ansible/roles/openvswitch/defaults/main.yml
+@@ -12,6 +12,7 @@ openvswitch_services:
+       or inventory_hostname in groups['neutron-dhcp-agent']
+       or inventory_hostname in groups['neutron-l3-agent']
+       or inventory_hostname in groups['neutron-metadata-agent']
++      or (enable_octavia | bool and inventory_hostname in groups['octavia-health-manager'])
+       }}
+     volumes: "{{ openvswitch_db_default_volumes + openvswitch_db_extra_volumes }}"
+     dimensions: "{{ openvswitch_db_dimensions }}"
+@@ -28,6 +29,7 @@ openvswitch_services:
+       or inventory_hostname in groups['neutron-dhcp-agent']
+       or inventory_hostname in groups['neutron-l3-agent']
+       or inventory_hostname in groups['neutron-metadata-agent']
++      or (enable_octavia | bool and inventory_hostname in groups['octavia-health-manager'])
+       }}
+     privileged: true
+     volumes: "{{ openvswitch_vswitchd_default_volumes + openvswitch_vswitchd_extra_volumes }}"

--- a/patches/2025.1/octavia-openvswitch.patch
+++ b/patches/2025.1/octavia-openvswitch.patch
@@ -1,0 +1,18 @@
+--- a/ansible/roles/openvswitch/defaults/main.yml
++++ b/ansible/roles/openvswitch/defaults/main.yml
+@@ -12,6 +12,7 @@ openvswitch_services:
+       or inventory_hostname in groups['neutron-dhcp-agent']
+       or inventory_hostname in groups['neutron-l3-agent']
+       or inventory_hostname in groups['neutron-metadata-agent']
++      or (enable_octavia | bool and inventory_hostname in groups['octavia-health-manager'])
+       }}
+     volumes: "{{ openvswitch_db_default_volumes + openvswitch_db_extra_volumes }}"
+     dimensions: "{{ openvswitch_db_dimensions }}"
+@@ -28,6 +29,7 @@ openvswitch_services:
+       or inventory_hostname in groups['neutron-dhcp-agent']
+       or inventory_hostname in groups['neutron-l3-agent']
+       or inventory_hostname in groups['neutron-metadata-agent']
++      or (enable_octavia | bool and inventory_hostname in groups['octavia-health-manager'])
+       }}
+     privileged: true
+     volumes: "{{ openvswitch_vswitchd_default_volumes + openvswitch_vswitchd_extra_volumes }}"


### PR DESCRIPTION
Enable openvswitch_db and openvswitch_vswitchd services on octavia-health-manager nodes when Octavia is enabled.