### PR TITLE
Change authkey file path to use correct shared directory

### DIFF
--- a/patches/2025.1/use-share-directory-for-authkey-files.patch
+++ b/patches/2025.1/use-share-directory-for-authkey-files.patch
@@ -57,7 +57,7 @@
    with_first_found:
      - "{{ node_custom_config }}/hacluster-pacemaker/{{ inventory_hostname }}/authkey"
      - "{{ node_custom_config }}/hacluster-pacemaker/authkey"
-+    - "/share/hacluster-corosync/authkey"
++    - "/share/hacluster-pacemaker/authkey"
  
  - name: Copying over Pacemaker authkey file into hacluster-pacemaker-remote
    vars:


### PR DESCRIPTION
Corosync was wrong on this place so we cannot place the corosync key on pacemaker and place the correct key to pacemaker