### PR TITLE
Update patch for authkey files of corosync and pacemaker

### DIFF
--- a/patches/2025.1/use-share-directory-for-authkey-files.patch
+++ b/patches/2025.1/use-share-directory-for-authkey-files.patch
@@ -57,7 +57,7 @@
    with_first_found:
      - "{{ node_custom_config }}/hacluster-pacemaker/{{ inventory_hostname }}/authkey"
      - "{{ node_custom_config }}/hacluster-pacemaker/authkey"
-+    - "/share/hacluster-corosync/authkey"
++    - "/share/hacluster-pacemaker/authkey"
  
  - name: Copying over Pacemaker authkey file into hacluster-pacemaker-remote
    vars:

--- a/patches/2025.2/use-share-directory-for-authkey-files.patch
+++ b/patches/2025.2/use-share-directory-for-authkey-files.patch
@@ -57,7 +57,7 @@
    with_first_found:
      - "{{ node_custom_config }}/hacluster-pacemaker/{{ inventory_hostname }}/authkey"
      - "{{ node_custom_config }}/hacluster-pacemaker/authkey"
-+    - "/share/hacluster-corosync/authkey"
++    - "/share/hacluster-pacemaker/authkey"
  
  - name: Copying over Pacemaker authkey file into hacluster-pacemaker-remote
    vars:


### PR DESCRIPTION
Fix the issue that the pacemaker key was copied to corosync

now it will be copied to the correct pacemaker file