### PR TITLE
Rename repository from cfg-generics -> generics

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -83,7 +83,7 @@ git clone https://github.com/osism/release /release
 
 # prepare project repository
 git clone https://github.com/osism/ansible-playbooks /playbooks
-git clone https://github.com/osism/cfg-generics /generics
+git clone https://github.com/osism/generics /generics
 git clone https://github.com/osism/kolla-operations /operations
 
 if [ "$VERSION" != "latest" ]; then

--- a/tests/gilt.yml
+++ b/tests/gilt.yml
@@ -1,5 +1,5 @@
 ---
-- git: https://github.com/osism/cfg-generics.git
+- git: https://github.com/osism/generics.git
   version: main
   files:
     - src: inventory/*


### PR DESCRIPTION
## Summary
- `osism/cfg-generics` was renamed to `osism/generics`. Update the `git clone` in the Containerfile and the gilt source in `tests/gilt.yml`.
- GitHub's rename alias keeps the old URLs working, so no behavior change is expected.

## Test plan
- [ ] Image build succeeds; `/generics` is populated from `osism/generics`
- [ ] `gilt overlay` in tests/ pulls from the new URL