### PR TITLE
horizon: healthcheck follows login redirect

### DIFF
--- a/patches/2024.2/horizon-healthcheck-login-page.patch
+++ b/patches/2024.2/horizon-healthcheck-login-page.patch
@@ -1,0 +1,11 @@
+--- a/ansible/roles/horizon/defaults/main.yml
++++ b/ansible/roles/horizon/defaults/main.yml
+@@ -111,7 +111,7 @@ horizon_enable_healthchecks: "{{ enable_container_healthchecks }}"
+ horizon_healthcheck_interval: "{{ default_container_healthcheck_interval }}"
+ horizon_healthcheck_retries: "{{ default_container_healthcheck_retries }}"
+ horizon_healthcheck_start_period: "{{ default_container_healthcheck_start_period }}"
+-horizon_healthcheck_test: ["CMD-SHELL", "healthcheck_curl {{ 'https' if horizon_enable_tls_backend | bool else 'http' }}://{{ api_interface_address | put_address_in_context('url') }}:{{ horizon_listen_port }}"]
++horizon_healthcheck_test: ["CMD-SHELL", "healthcheck_curl -L {{ 'https' if horizon_enable_tls_backend | bool else 'http' }}://{{ api_interface_address | put_address_in_context('url') }}:{{ horizon_listen_port }}"]
+ horizon_healthcheck_timeout: "{{ default_container_healthcheck_timeout }}"
+ horizon_healthcheck:
+   interval: "{{ horizon_healthcheck_interval }}"

--- a/patches/2025.1/horizon-healthcheck-login-page.patch
+++ b/patches/2025.1/horizon-healthcheck-login-page.patch
@@ -1,0 +1,11 @@
+--- a/ansible/roles/horizon/defaults/main.yml
++++ b/ansible/roles/horizon/defaults/main.yml
+@@ -111,7 +111,7 @@ horizon_enable_healthchecks: "{{ enable_container_healthchecks }}"
+ horizon_healthcheck_interval: "{{ default_container_healthcheck_interval }}"
+ horizon_healthcheck_retries: "{{ default_container_healthcheck_retries }}"
+ horizon_healthcheck_start_period: "{{ default_container_healthcheck_start_period }}"
+-horizon_healthcheck_test: ["CMD-SHELL", "healthcheck_curl {{ 'https' if horizon_enable_tls_backend | bool else 'http' }}://{{ api_interface_address | put_address_in_context('url') }}:{{ horizon_listen_port }}"]
++horizon_healthcheck_test: ["CMD-SHELL", "healthcheck_curl -L {{ 'https' if horizon_enable_tls_backend | bool else 'http' }}://{{ api_interface_address | put_address_in_context('url') }}:{{ horizon_listen_port }}"]
+ horizon_healthcheck_timeout: "{{ default_container_healthcheck_timeout }}"
+ horizon_healthcheck:
+   interval: "{{ horizon_healthcheck_interval }}"

--- a/patches/2025.2/horizon-healthcheck-login-page.patch
+++ b/patches/2025.2/horizon-healthcheck-login-page.patch
@@ -1,0 +1,11 @@
+--- a/ansible/roles/horizon/defaults/main.yml
++++ b/ansible/roles/horizon/defaults/main.yml
+@@ -111,7 +111,7 @@ horizon_enable_healthchecks: "{{ enable_container_healthchecks }}"
+ horizon_healthcheck_interval: "{{ default_container_healthcheck_interval }}"
+ horizon_healthcheck_retries: "{{ default_container_healthcheck_retries }}"
+ horizon_healthcheck_start_period: "{{ default_container_healthcheck_start_period }}"
+-horizon_healthcheck_test: ["CMD-SHELL", "healthcheck_curl {{ 'https' if horizon_enable_tls_backend | bool else 'http' }}://{{ api_interface_address | put_address_in_context('url') }}:{{ horizon_listen_port }}"]
++horizon_healthcheck_test: ["CMD-SHELL", "healthcheck_curl -L {{ 'https' if horizon_enable_tls_backend | bool else 'http' }}://{{ api_interface_address | put_address_in_context('url') }}:{{ horizon_listen_port }}"]
+ horizon_healthcheck_timeout: "{{ default_container_healthcheck_timeout }}"
+ horizon_healthcheck:
+   interval: "{{ horizon_healthcheck_interval }}"


### PR DESCRIPTION
## What

Make the Horizon container healthcheck follow the redirect from `/` to the
login page (add `-L`), so a broken django-compressor offline manifest is
detected instead of being masked.

## Why

The stock healthcheck curls `/`, which Horizon answers with a 302 redirect to
the login page. `healthcheck_curl` is `curl --fail` **without** `-L`, so the 302
counts as success and the login page is never rendered. A broken offline
manifest only fails when the login page renders (HTTP 500,
`OfflineGenerationError`), so the container stays `healthy` and HAProxy keeps
routing to a backend that serves 500s on roughly every 2nd/3rd request.
See osism/issues#1363 (split from #1360).

## How

Add `-L` to `horizon_healthcheck_test` so curl follows the redirect and fetches
the login page, which renders the offline-compressed block. A backend with a
missing/stale manifest is now reported `unhealthy`. The login page renders
without a Keystone round-trip, so it stays a lightweight liveness probe.

Following the redirect (rather than hardcoding `/auth/login/`) keeps the check
correct under a custom `WEBROOT`: kolla-ansible has no WEBROOT variable, so a
hardcoded path would 404 and mark a healthy container unhealthy. It does rely on
`/` redirecting to the dashboard, which the stock kolla vhost does.

Patches for 2024.2, 2025.1 and 2025.2 (byte-identical). This carries the fix
until an equivalent change lands upstream in `openstack/kolla-ansible`.

## Verification

Verified end-to-end on a 3-controller testbed (OpenStack 2024.2) with the patched
kolla-ansible image injected via `testbed-operator.py deploy --local-image`:

- Clean deploy: all three horizon containers `healthy`; the `-L` probe returns
  exit 0 (no false negative).
- Reproduced the real failure mode on one controller — removed the offline
  manifest (`.../static/dashboard/manifest.json`; Horizon sets
  `COMPRESS_OUTPUT_DIR=dashboard`) and restarted, so `extend_start.sh` skipped
  `compress` (settings unchanged) and the worker came up with no manifest → the
  login page returns HTTP 500.
- On the broken backend the healthcheck command (what Docker runs) returns
  **exit 0 without `-L`** (misses it) and **exit 1 with `-L`** (catches it).
- A non-zero healthcheck marks the container `unhealthy`: confirmed in an
  equivalent run where the affected backend went `unhealthy` while the other two
  stayed `healthy`, and recovered once the manifest was restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)