### PR TITLE
fix: pin CycloneDX spec version to 1.6 for SBOM upload

### DIFF
--- a/playbooks/build.yml
+++ b/playbooks/build.yml
@@ -185,7 +185,7 @@
           fi
 
           curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sudo sh -s -- -b /usr/local/bin
-          /usr/local/bin/syft scan "$repository:$version" -o cyclonedx-json > sbom.json
+          /usr/local/bin/syft scan "$repository:$version" -o cyclonedx-json@1.6 > sbom.json
           {{ python_venv_dir }}/bin/dtrackauditor \
             -p kolla-ansible \
             -v "$version" \


### PR DESCRIPTION
## Problem

The SBOM upload to DependencyTrack fails with:

```
HTTP-400 Bad Request => {"status":400,"title":"The uploaded BOM is invalid","detail":"Unrecognized specVersion 1.7"}
```

`syft` is installed unpinned (`latest`) and now defaults to emitting CycloneDX **specVersion 1.7**. DependencyTrack does not yet support 1.7 and rejects the upload.

## Fix

Pin the syft output format to `cyclonedx-json@1.6`, the highest CycloneDX spec version DependencyTrack currently accepts. This makes the SBOM upload independent of syft's evolving default.

Same fix as:

- osism/container-image-osism-ansible#757

🤖 Generated with [Claude Code](https://claude.com/claude-code)