### PR TITLE
ironic: bound IPA image download with timeout

### DIFF
--- a/files/playbooks/kolla-ironic-download-ipa-images.yml
+++ b/files/playbooks/kolla-ironic-download-ipa-images.yml
@@ -28,6 +28,7 @@
         dest: "{{ ironic_agent_files_directory }}/ironic/ironic-agent.initramfs"
         checksum: "{{ ironic_agent_initramfs_checksum }}"
         mode: 0644
+        timeout: 120
       when: enable_ironic_agent_download_images | bool
       environment: "{{ proxy_proxies | default({}) }}"
       register: result
@@ -41,6 +42,7 @@
         dest: "{{ ironic_agent_files_directory }}/ironic/ironic-agent.kernel"
         checksum: "{{ ironic_agent_kernel_checksum }}"
         mode: 0644
+        timeout: 120
       when: enable_ironic_agent_download_images | bool
       environment: "{{ proxy_proxies | default({}) }}"
       register: result


### PR DESCRIPTION
## Problem

The `Download ironic ipa images` play fetches the IPA initramfs and kernel from `tarballs.opendev.org` with `ansible.builtin.get_url`, but neither task set a `timeout`. `get_url`'s default `timeout` (10s) bounds only the initial connect, never the transfer — so a connection that opens and then stalls mid-transfer hangs indefinitely. With `retries: 3` a slow night compounds into a multi-hour stall.

On 2026-07-02 (build [`70b8e4aa`](https://zuul.services.osism.tech/t/osism/build/70b8e4aa0fa144d887e150affa594cb3), `testbed-deploy-next-in-a-nutshell-with-tempest-ubuntu-24.04`) the initramfs download stalled for **10790s (~3h)**. The deploy was otherwise healthy and resumed once the download finally completed, but the wasted time pushed the job past its ~4h30m Zuul timeout (`TIMED_OUT`) before tempest could run. The idle `osism apply` celery chain also tripped the informational `kolla-collection-celery-task-stuck` signature, masking the real cause.

## Change

Set `timeout: 120` on both `get_url` tasks. A stalled host now fails fast (~8 min worst case across the retries) with a clear, attributable error instead of hanging for hours.

## Why 120s will not break a working-but-slow download

`get_url`'s `timeout` is a **socket-level read timeout, not a cap on total transfer time** — it fires only when the connection delivers zero bytes for 120 continuous seconds. A slow-but-live transfer keeps `recv()` returning partial data far more often than that, so it never trips regardless of file size or total duration.

The initramfs is the only sizeable artifact (~490 MiB for 2025.1; the kernel is ~15 MiB). Even on a 1 Mbit/s line it streams to completion in ~69 min without a single 120s gap:

| Sustained rate | Full initramfs (~490 MiB) | Trips `timeout: 120`? |
|---|---|---|
| 1 Mbit/s | ~69 min | No |
| 5 Mbit/s | ~14 min | No |
| 20 Mbit/s | ~3.4 min | No |

Only a genuinely dead connection — the failure we are targeting — stays silent for 120s. The margin also covers the multi-second stalls a lossy line can incur during TCP retransmission.

This bounds the blast radius; it does **not** remove the external dependency on `tarballs.opendev.org` (a local mirror / using the testbed's already-synced image would — tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)