### PR TITLE
overlays: drop dead 2025.x ceph keyrings

### DIFF
--- a/overlays/2025.1/kolla-ansible.yml
+++ b/overlays/2025.1/kolla-ansible.yml
@@ -1,12 +1,4 @@
 ---
-# External Ceph keyrings
-ceph_cinder_keyring: "client.{{ ceph_cinder_user }}.keyring"
-ceph_cinder_backup_keyring: "client.{{ ceph_cinder_backup_user }}.keyring"
-ceph_glance_keyring: "client.{{ ceph_glance_user }}.keyring"
-ceph_gnocchi_keyring: "client.{{ ceph_gnocchi_user }}.keyring"
-ceph_manila_keyring: "client.{{ ceph_manila_user }}.keyring"
-ceph_nova_keyring: "client.{{ ceph_nova_user }}.keyring"
-
 # https://mariadb.com/kb/en/mariabackup-overview/#authentication-and-privileges
 #
 # To use the --history option, the backup user also needs to have the following privileges granted:

--- a/overlays/2025.2/kolla-ansible.yml
+++ b/overlays/2025.2/kolla-ansible.yml
@@ -1,12 +1,4 @@
 ---
-# External Ceph keyrings
-ceph_cinder_keyring: "client.{{ ceph_cinder_user }}.keyring"
-ceph_cinder_backup_keyring: "client.{{ ceph_cinder_backup_user }}.keyring"
-ceph_glance_keyring: "client.{{ ceph_glance_user }}.keyring"
-ceph_gnocchi_keyring: "client.{{ ceph_gnocchi_user }}.keyring"
-ceph_manila_keyring: "client.{{ ceph_manila_user }}.keyring"
-ceph_nova_keyring: "client.{{ ceph_nova_user }}.keyring"
-
 # https://mariadb.com/kb/en/mariabackup-overview/#authentication-and-privileges
 #
 # To use the --history option, the backup user also needs to have the following privileges granted:


### PR DESCRIPTION
## What

Remove the six `ceph_*_keyring` variables from the **2025.1** and **2025.2** per-release overlays (`overlays/2025.1/kolla-ansible.yml`, `overlays/2025.2/kolla-ansible.yml`). The 2023.2 / 2024.1 / 2024.2 overlays are untouched.

## Why

These overlays inject group_vars into the kolla-ansible image per release. The `ceph_*_keyring` vars fed the external-Ceph client keyring filenames. Upstream kolla-ansible **removed** those variables in the 2025.1 cycle — "Enhance Ceph Integration for Multiple Clusters" (`I2593b6df`, https://review.opendev.org/q/I2593b6df737b384f1a5fba22f69e851c575990b4), present in `stable/2025.1` but not `2024.2`.

They were an intermediate fragment, not the full filename: in 2024.2 the roles combined them with the cluster name (e.g. cinder used `{{ item.cluster }}.{{ ceph_cinder_keyring }}`). To support multiple Ceph clusters, 2025.x builds the whole name inline (`{{ item.cluster }}.client.{{ item.user }}.keyring`). The default on-disk filename (`ceph.client.<user>.keyring`) is unchanged — only the intermediate variable is gone.

So at `stable/2025.1` and `stable/2025.2` upstream neither **defines** these vars in `group_vars/all` nor **references** them in any role — the 2025.x overlay copies set variables nothing reads. They are dead.

The **2024.1 / 2024.2** overlays keep their entries: upstream still defines and consumes `ceph_*_keyring` there (the `external_ceph` tasks and service config templates in cinder/glance/gnocchi/manila/nova-cell/zun). Those expire when 2024.x leaves support.

## Verification

- Upstream: `ceph_*_keyring` defined + consumed at 2024.1/2024.2; **0** definitions and **0** role references at 2025.1/2025.2.
- OSISM drift detector (kolla group) stays `0 to act on, 0 stale` after the removal — the keyrings remain supplied by the 2024.x overlays for the releases that consume them.
- OSISM keyring provisioning (`ansible-playbooks` `copy-ceph-keys.yml`, cfg-cookiecutter, testbed, tbng) already uses `ceph.client.<user>.keyring`, matching both 2024.x and 2025.x — no companion change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
