### PR TITLE
kolla-rgw-endpoint: pass container_engine

### DIFF
--- a/files/playbooks/kolla-rgw-endpoint.yml
+++ b/files/playbooks/kolla-rgw-endpoint.yml
@@ -35,6 +35,7 @@
     - name: Creating the ResellerAdmin role  # noqa run-once[task] osism-fqcn
       become: true
       kolla_toolbox:
+        container_engine: "{{ kolla_container_engine | default('docker') }}"
         module_name: "os_keystone_role"
         module_args:
           name: "ResellerAdmin"


### PR DESCRIPTION
The "Creating the ResellerAdmin role" task in `kolla-rgw-endpoint.yml` calls `kolla_toolbox` without the `container_engine` argument. kolla-ansible's `kolla_toolbox` module has required `container_engine` (choices docker/podman, no default) since it was introduced (2022-11-04), in every OpenStack version this image builds (2023.2..2025.2), so on current kolla-ansible the task fails with `missing required arguments: container_engine`.

This playbook is the intended way to add the Swift/RGW Keystone endpoint for a Ceph deployment not managed by kolla's `enable_ceph_rgw` path, so operators using it hit the failure.

Fix: pass `container_engine: "{{ kolla_container_engine | default('docker') }}"`, matching the existing precedent in `files/playbooks/kolla-purge-rabbitmq.yml`. The `default('docker')` guard is needed because kolla-ansible's `group_vars/all` default for `kolla_container_engine` is not copied into this image.

Verified against the `ansible-lint` image with the real `kolla_toolbox` module on `ANSIBLE_LIBRARY`: the `args[module]: missing required arguments: container_engine` error is gone and lint passes clean.

Draft: opened for review; not marking ready until the reviewer confirms the argument value/default is right for the intended (non-kolla-managed Ceph) use.

Related:

- osism/issues#1412

🤖 Generated with [Claude Code](https://claude.com/claude-code)