### PR TITLE
keystone: allow multiple OIDCXForwardedHeaders options

### DIFF
--- a/patches/2025.1/keystone-multiple-oidcxforwardedheaders.patch
+++ b/patches/2025.1/keystone-multiple-oidcxforwardedheaders.patch
@@ -1,0 +1,62 @@
+From 6629f4cc03bd2d13fb8e287bfdc7c16448689022 Mon Sep 17 00:00:00 2001
+From: Michel Raabe <raabe@b1-systems.de>
+Date: Wed, 3 Jun 2026 12:50:32 +0200
+Subject: [PATCH] keystone: allow multiple OIDCXForwardedHeaders options
+
+The OIDCXForwardedHeaders directive from mod_auth_openidc accepts a
+space-separated list of header names and parses each one as a separate
+argument. The keystone httpd template wrapped the value in double
+quotes, so Apache passed the whole list as a single argument. As a
+result, only a single forwarded header could be configured and setting
+more than one value failed.
+
+Remove the surrounding quotes so that each header name is parsed as an
+individual argument, allowing more than one forwarded header to be set.
+
+Conflicts:
+  ansible/roles/keystone/templates/httpd-keystone.conf.j2
+
+Fix applied to wsgi-keystone.conf.j2 instead.
+
+Closes-Bug: #2155147
+Change-Id: Id23fbdf6c82acdec1ee310b6b29fc4a5dc846f66
+Signed-off-by: Michel Raabe <raabe@b1-systems.de>
+(cherry picked from commit 6a710101850a13518d66bd0e7c27a3ee54a3c2d8)
+(cherry picked from commit e8193097388372e4f29eaf32138a5ccde790c4e5)
+(cherry picked from commit 517e8247c86cd4a5cc0ff554d1541d235c6df2e3)
+---
+ ansible/roles/keystone/templates/wsgi-keystone.conf.j2    | 2 +-
+ .../fix-oidc-forwarded-headers-2b3b670e3732ca86.yaml      | 8 ++++++++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+ create mode 100644 releasenotes/notes/fix-oidc-forwarded-headers-2b3b670e3732ca86.yaml
+
+diff --git a/ansible/roles/keystone/templates/wsgi-keystone.conf.j2 b/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
+index 427c36d10..ecb9f4fb1 100644
+--- a/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
++++ b/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
+@@ -59,7 +59,7 @@ LogLevel info
+ 
+ {% if keystone_enable_federation_openid | bool %}
+ {% if keystone_federation_oidc_forwarded_headers | length > 0 %}
+-    OIDCXForwardedHeaders "{{ keystone_federation_oidc_forwarded_headers }}"
++    OIDCXForwardedHeaders {{ keystone_federation_oidc_forwarded_headers }}
+ {% endif %}
+     OIDCClaimPrefix "OIDC-"
+     OIDCClaimDelimiter "{{ keystone_federation_oidc_claim_delimiter }}"
+diff --git a/releasenotes/notes/fix-oidc-forwarded-headers-2b3b670e3732ca86.yaml b/releasenotes/notes/fix-oidc-forwarded-headers-2b3b670e3732ca86.yaml
+new file mode 100644
+index 000000000..ef3fc14e2
+--- /dev/null
++++ b/releasenotes/notes/fix-oidc-forwarded-headers-2b3b670e3732ca86.yaml
+@@ -0,0 +1,8 @@
++---
++fixes:
++  - |
++    Fixes the ``OIDCXForwardedHeaders`` directive in the Keystone Apache
++    configuration. The value was previously wrapped in double quotes, which
++    caused Apache to treat the whole list as a single argument and prevented
++    configuring more than one forwarded header. See `LP#2155147
++    <https://bugs.launchpad.net/kolla-ansible/+bug/2155147>`__.
+-- 
+2.47.3
+

--- a/patches/2025.2/keystone-multiple-oidcxforwardedheaders.patch
+++ b/patches/2025.2/keystone-multiple-oidcxforwardedheaders.patch
@@ -1,0 +1,56 @@
+From 517e8247c86cd4a5cc0ff554d1541d235c6df2e3 Mon Sep 17 00:00:00 2001
+From: Michel Raabe <raabe@b1-systems.de>
+Date: Wed, 3 Jun 2026 12:50:32 +0200
+Subject: [PATCH] keystone: allow multiple OIDCXForwardedHeaders options
+
+The OIDCXForwardedHeaders directive from mod_auth_openidc accepts a
+space-separated list of header names and parses each one as a separate
+argument. The keystone httpd template wrapped the value in double
+quotes, so Apache passed the whole list as a single argument. As a
+result, only a single forwarded header could be configured and setting
+more than one value failed.
+
+Remove the surrounding quotes so that each header name is parsed as an
+individual argument, allowing more than one forwarded header to be set.
+
+Closes-Bug: #2155147
+Change-Id: Id23fbdf6c82acdec1ee310b6b29fc4a5dc846f66
+Signed-off-by: Michel Raabe <raabe@b1-systems.de>
+(cherry picked from commit 6a710101850a13518d66bd0e7c27a3ee54a3c2d8)
+(cherry picked from commit e8193097388372e4f29eaf32138a5ccde790c4e5)
+---
+ ansible/roles/keystone/templates/httpd-keystone.conf.j2   | 2 +-
+ .../fix-oidc-forwarded-headers-2b3b670e3732ca86.yaml      | 8 ++++++++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+ create mode 100644 releasenotes/notes/fix-oidc-forwarded-headers-2b3b670e3732ca86.yaml
+
+diff --git a/ansible/roles/keystone/templates/httpd-keystone.conf.j2 b/ansible/roles/keystone/templates/httpd-keystone.conf.j2
+index 435fe7cdd..1e54855bb 100644
+--- a/ansible/roles/keystone/templates/httpd-keystone.conf.j2
++++ b/ansible/roles/keystone/templates/httpd-keystone.conf.j2
+@@ -53,7 +53,7 @@ LogLevel info
+ 
+ {% if keystone_enable_federation_openid | bool %}
+ {% if keystone_federation_oidc_forwarded_headers | length > 0 %}
+-    OIDCXForwardedHeaders "{{ keystone_federation_oidc_forwarded_headers }}"
++    OIDCXForwardedHeaders {{ keystone_federation_oidc_forwarded_headers }}
+ {% endif %}
+     OIDCClaimPrefix "OIDC-"
+     OIDCClaimDelimiter "{{ keystone_federation_oidc_claim_delimiter }}"
+diff --git a/releasenotes/notes/fix-oidc-forwarded-headers-2b3b670e3732ca86.yaml b/releasenotes/notes/fix-oidc-forwarded-headers-2b3b670e3732ca86.yaml
+new file mode 100644
+index 000000000..ef3fc14e2
+--- /dev/null
++++ b/releasenotes/notes/fix-oidc-forwarded-headers-2b3b670e3732ca86.yaml
+@@ -0,0 +1,8 @@
++---
++fixes:
++  - |
++    Fixes the ``OIDCXForwardedHeaders`` directive in the Keystone Apache
++    configuration. The value was previously wrapped in double quotes, which
++    caused Apache to treat the whole list as a single argument and prevented
++    configuring more than one forwarded header. See `LP#2155147
++    <https://bugs.launchpad.net/kolla-ansible/+bug/2155147>`__.
+-- 
+2.47.3
+


### PR DESCRIPTION
Backports for upstream reviews:

- https://review.opendev.org/c/openstack/kolla-ansible/+/998910
- https://review.opendev.org/c/openstack/kolla-ansible/+/998912