### PR TITLE
2025.2: use the fast inventory directory

### DIFF
--- a/files/scripts/2025.2/run.sh
+++ b/files/scripts/2025.2/run.sh
@@ -27,7 +27,11 @@ if [[ -e /ansible/ara.env ]]; then
     source /ansible/ara.env
 fi
 
-export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+if [[ -d $ANSIBLE_DIRECTORY/inventory/fast ]]; then
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/fast
+else
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+fi
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
 if [[ -e $ANSIBLE_DIRECTORY/inventory/ansible/ansible.cfg ]]; then
@@ -36,7 +40,7 @@ elif [[ -e $ENVIRONMENTS_DIRECTORY/$SUB/ansible.cfg ]]; then
     export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/$SUB/ansible.cfg
 fi
 
-if [[ -w $ANSIBLE_INVENTORY ]]; then
+if [[ ! -d $ANSIBLE_DIRECTORY/inventory/fast ]] && [[ -w $ANSIBLE_INVENTORY ]]; then
     rsync -a /ansible/group_vars/ /ansible/inventory/group_vars/
     rsync -a /ansible/inventory.generics/ /ansible/inventory/
     rsync -a /opt/configuration/inventory/ /ansible/inventory/


### PR DESCRIPTION
`files/scripts/2025.2/run.sh` is the only release script that does not prefer the
reconciler's `inventory/fast` directory. That looks like a missed forward-port
rather than a decision — the 2025.2 directory was created in one PR, and the very
next one added the fast-inventory selection to every *other* release:

- osism/container-image-kolla-ansible#871
- osism/container-image-kolla-ansible#872

Today `grep -c inventory/fast files/scripts/*/run.sh` gives 3 for 2023.2, 2024.1,
2024.2 and 2025.1, and 0 for 2025.2.

## Why it matters

`group_vars` are loaded relative to the inventory source. `inventory/fast` is a
directory containing `group_vars/all`; the bare `hosts.yml` has no `group_vars`
beside it.

Hosts are unaffected, because the reconciler also inlines the variables per host
inside `hosts.yml`. **Plays targeting `localhost` are not**: an implicit localhost
has no entry there and can only be fed from `group_vars`, so on 2025.2 it receives
none of the OSISM kolla defaults.

The reachable symptom today is `osism apply octavia-certificates`, which fails with
`'node_config' is undefined`. Defining that variable by hand only moves the error:
the role's own default then resolves to a path under the read-only
`/opt/configuration` mount and it fails again with `[Errno 30] Read-only file system`.
OSISM's `octavia_certs_work_dir: /share` override exists precisely to avoid that
path — and it is another `group_vars` default localhost never sees.

## Evidence for the breakage, and for the fix

Both halves come out of one experiment. On a single 2025.2 manager — same host,
same container, same reconciler data — only `ANSIBLE_INVENTORY` was varied. The
first row is what 2025.2 does today; the second is what this PR makes it do, and
what every other release already does:

| `ANSIBLE_INVENTORY` | corresponds to | `node_config` | `octavia_certs_work_dir` |
|---|---|---|---|
| `…/inventory/hosts.yml` | 2025.2 today | **undefined** | **undefined** |
| `…/inventory/fast` | other releases, and 2025.2 with this PR | `/etc/kolla` | `/share` |

Confirming the fix end to end rather than only at the variable level: an image
built from `kolla-ansible:2025.2` carrying **only** this `run.sh` change runs
`osism apply octavia-certificates` to completion through the normal path, with no
extra variables of any kind — `ok=12 changed=11 failed=0` (certs deleted first, so
they were really regenerated rather than skipped).

After the port, `files/scripts/2025.2/run.sh` is byte-identical to
`files/scripts/2025.1/run.sh`, so this restores parity rather than inventing a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)